### PR TITLE
fix TypeError

### DIFF
--- a/lib/pretty_backtrace.rb
+++ b/lib/pretty_backtrace.rb
@@ -41,7 +41,7 @@ module PrettyBacktrace
               begin
                 v = b.local_variable_get(lv).inspect
                 r[lv] = v
-              rescue NameError
+              rescue NameError,TypeError
                 # ignore
               end
               r

--- a/test.rb
+++ b/test.rb
@@ -3,6 +3,12 @@ require 'pretty_backtrace/enable'
 
 PrettyBacktrace::multi_line = true
 
+1.times{|*|
+  raise
+}
+
+__END__
+
 1.times{
   2.times{
     3.times{


### PR DESCRIPTION
I got the following error:

```
$ ruby -v -rpretty_backtrace/enable -e '1.times{|*|raise}'
ruby 2.2.3p173 (2015-08-18 revision 51636) [x86_64-linux]
...
2 is not a symbol nor a string
/usr/local/ruby-2.2/lib/ruby/gems/2.2.0/gems/pretty_backtrace-0.1.2/lib/pretty_backtrace.rb:42:in `local_variable_get'
/usr/local/ruby-2.2/lib/ruby/gems/2.2.0/gems/pretty_backtrace-0.1.2/lib/pretty_backtrace.rb:42:in `block (4 levels) in <module:PrettyBacktrace>'
/usr/local/ruby-2.2/lib/ruby/gems/2.2.0/gems/pretty_backtrace-0.1.2/lib/pretty_backtrace.rb:40:in `each'
/usr/local/ruby-2.2/lib/ruby/gems/2.2.0/gems/pretty_backtrace-0.1.2/lib/pretty_backtrace.rb:40:in `inject'
/usr/local/ruby-2.2/lib/ruby/gems/2.2.0/gems/pretty_backtrace-0.1.2/lib/pretty_backtrace.rb:40:in `block (3 levels) in <module:PrettyBacktrace>'
/usr/local/ruby-2.2/lib/ruby/gems/2.2.0/gems/pretty_backtrace-0.1.2/lib/pretty_backtrace.rb:31:in `map'
/usr/local/ruby-2.2/lib/ruby/gems/2.2.0/gems/pretty_backtrace-0.1.2/lib/pretty_backtrace.rb:31:in `with_index'
/usr/local/ruby-2.2/lib/ruby/gems/2.2.0/gems/pretty_backtrace-0.1.2/lib/pretty_backtrace.rb:31:in `block (2 levels) in <module:PrettyBacktrace>'
/usr/local/ruby-2.2/lib/ruby/gems/2.2.0/gems/pretty_backtrace-0.1.2/lib/pretty_backtrace.rb:25:in `open'
/usr/local/ruby-2.2/lib/ruby/gems/2.2.0/gems/pretty_backtrace-0.1.2/lib/pretty_backtrace.rb:25:in `block in <module:PrettyBacktrace>'
-e:1:in `block in <main>'
-e:1:in `times'
-e:1:in `<main>'
```
