### PR TITLE
Reject names of unsupported class in lvs

### DIFF
--- a/lib/pretty_backtrace.rb
+++ b/lib/pretty_backtrace.rb
@@ -63,7 +63,7 @@ module PrettyBacktrace
 
   def self.iseq_local_variables iseq
     _,_,_,_,arg_info,name,path,a_path,_,type,lvs, * = iseq.to_a
-    lvs
+    lvs.select{|lv| lv.is_a?(Symbol) || lv.is_a?(String) }
   end
 
   #


### PR DESCRIPTION
以下のようなコードを実行すると

``` ruby
require 'pretty_backtrace'
PrettyBacktrace.enable

def t(*)
  l = 'a'
  raise 'a'
end

t(a: 1, b: 2)
```

このようなエラーがでました

```
% ruby /tmp/a.rb
3 is not a symbol nor a string
/path/to/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/pretty_backtrace-0.1.2/lib/pretty_backtrace.rb:42:in `local_variable_get'
/path/to/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/pretty_backtrace-0.1.2/lib/pretty_backtrace.rb:42:in `block (4 levels) in </path/tottyBacktrace>'
/path/to/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/pretty_backtrace-0.1.2/lib/pretty_backtrace.rb:40:in `each'
/path/to/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/pretty_backtrace-0.1.2/lib/pretty_backtrace.rb:40:in `inject'
/path/to/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/pretty_backtrace-0.1.2/lib/pretty_backtrace.rb:40:in `block (3 levels) in </path/tottyBacktrace>'
/path/to/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/pretty_backtrace-0.1.2/lib/pretty_backtrace.rb:31:in `map'
/path/to/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/pretty_backtrace-0.1.2/lib/pretty_backtrace.rb:31:in `with_index'
/path/to/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/pretty_backtrace-0.1.2/lib/pretty_backtrace.rb:31:in `block (2 levels) in </path/tottyBacktrace>'
/path/to/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/pretty_backtrace-0.1.2/lib/pretty_backtrace.rb:25:in `open'
/path/to/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/pretty_backtrace-0.1.2/lib/pretty_backtrace.rb:25:in `block in <module:PrettyBacktrace>'
/tmp/a.rb:6:in `t'
/tmp/a.rb:9:in `<main>'
exit status: 1
```

取得するローカル変数の名前に「3」というFixnumが入るのが原因のようです。
Ruby本体側の変更だとも思われるんですが、一応ライブラリ側でも回避するように修正してみました。

Rubyのバージョン

```
% ruby -v
ruby 2.2.3p173 (2015-08-18 revision 51636) [x86_64-linux]
```

pretty_backtraceのバージョンは0.1.2です。
