### PR TITLE
Support Ruby3

### DIFF
--- a/lib/pretty_backtrace.rb
+++ b/lib/pretty_backtrace.rb
@@ -78,7 +78,7 @@ module PrettyBacktrace
       additional = ''
 
       # file scope
-      if CONFIG[:file_contents] && File.exists?(absolute_path)
+      if CONFIG[:file_contents] && absolute_path && File.exists?(absolute_path)
         fclines = CONFIG[:file_contents_lines]
         start_line = lineno - 1 - 1 * fclines
         start_line = 0 if start_line < 0

--- a/pretty_backtrace.gemspec
+++ b/pretty_backtrace.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "debug_inspector", "~> 0.0.1"
+  spec.add_runtime_dependency "debug_inspector", "~> 1.1.0"
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
[debug_inspector](https://github.com/banister/debug_inspector) supports Ruby3 from version 1.0.0 https://github.com/banister/debug_inspector/pull/24 .
But current version of pretty_backtrace can't use more than version 1.0.0 of debug_inspector.
So, We can support Ruby3 by increasing the version of debug_inspector.